### PR TITLE
Make hideInContents a formula

### DIFF
--- a/xlsxconverter/XLSXConverter2.js
+++ b/xlsxconverter/XLSXConverter2.js
@@ -258,7 +258,8 @@ var XLSXConverter = {};
             uri: 'formula', // queries
             callback: 'formula(context)', // queries
             choice_filter: 'formula(choice_item)', // expects "choice" context arg.
-            templatePath: 'requirejs_path'
+            templatePath: 'requirejs_path',
+            hideInContents: 'formula'
     };
 
     //The prompt type map is not kept in a separate JSON file because


### PR DESCRIPTION
This change marks the `hideInContents` column as a `formula`. This will allow expressions in `hideInContents` so irrelevant prompts can be hidden in the table of contents. After this change `hideInContents` will work like `required` and `constraint`.