### PR TITLE
Fix  #185 : use translation key for the table of contents heading

### DIFF
--- a/app/system/survey/templates/contents.handlebars
+++ b/app/system/survey/templates/contents.handlebars
@@ -1,4 +1,4 @@
-<h4>Contents</h4>
+<h4>{{localizeText display.options_popup_contents_heading}}</h4>
 <div class="btn-group-vertical" style="display:block; padding:5px">
     {{#each prompts}}
         {{#unless hideInContents}}

--- a/app/system/survey/templates/contents.handlebars
+++ b/app/system/survey/templates/contents.handlebars
@@ -1,4 +1,4 @@
-<h4>{{localizeText display.options_popup_contents_heading}}</h4>
+<h4>{{localizeText 'options_popup_contents_heading'}}</h4>
 <div class="btn-group-vertical" style="display:block; padding:5px">
     {{#each prompts}}
         {{#unless hideInContents}}


### PR DESCRIPTION
Fixes issue [#185](https://github.com/odk-x/tool-suite-X/issues/185)

**What changes have been made?**

- Replaced hard coded string `Contents` with a previously defined translation key `options_popup_contents_heading` having value `Contents` in `contents.handlebars`