### PR TITLE
Fix #157 - Trim whitespace from column name in XLSX Converter

### DIFF
--- a/xlsxconverter/XLSXConverter2.js
+++ b/xlsxconverter/XLSXConverter2.js
@@ -582,6 +582,7 @@ var XLSXConverter = {};
                 value = value.replace(/\r/g, "");
                 value = value.trim();
             }
+            key = key.trim();
             outRow[key] = value;
         });
         return outRow;


### PR DESCRIPTION
closes odk-x/tool-suite-X#157

#### What is included in this PR?
1. Trim trailing whitespace from both ends of the column name string in XLSX Converter using the `trim()` method

Tested locally to ensure it didn't break.